### PR TITLE
Test Mechanism of Joke App

### DIFF
--- a/practice_app/app.py
+++ b/practice_app/app.py
@@ -41,6 +41,14 @@ def joke_get_user(user_name):
         return None
 
 
+@app.route('/joke/delete_user/<user_name>', methods=["DELETE"])
+def joke_delete_user(user_name):
+    if request.method == "DELETE":
+        return helper_functions.delete_user(user_name, joke_collection)
+    else:
+        return None
+
+
 @app.route('/joke/add_to_list/<user_name>/<set_up>/<punch_line>', methods=["GET", "PUT"])
 def joke_add_to_list(user_name, set_up, punch_line):
     if request.method == "PUT":

--- a/practice_app/helpers/helper_functions.py
+++ b/practice_app/helpers/helper_functions.py
@@ -9,7 +9,10 @@ def get_user(user_name, collection):
 
 def add_user(user_name, collection):
     x = collection.insert_one({"name": user_name, "jokes": []})
-    return x
+    value = {
+        "id": str(x.inserted_id)
+    }
+    return value
 
 
 def add_to_list(user_name, set_up, punch_line, collection):
@@ -22,4 +25,18 @@ def add_to_list(user_name, set_up, punch_line, collection):
     else:
         user_jokes.append({'set_up': set_up, 'punch_line': punch_line})
         x = collection.update_one({"name": user_name}, {"$set": {'jokes': user_jokes}})
-    return x
+
+    value = {
+        "modified_count": x.modified_count,
+        "id": x.upserted_id,
+    }
+    return value
+
+
+def delete_user(user_name, collection):
+    x = collection.delete_one({"name": user_name})
+    value = {
+        "deleted_count": x.deleted_count
+    }
+    return value
+

--- a/practice_app/helpers/helper_functions.py
+++ b/practice_app/helpers/helper_functions.py
@@ -12,7 +12,7 @@ def add_user(user_name, collection):
     value = {
         "id": str(x.inserted_id)
     }
-    return value
+    return value, 201
 
 
 def add_to_list(user_name, set_up, punch_line, collection):

--- a/practice_app/tests/test.py
+++ b/practice_app/tests/test.py
@@ -103,7 +103,7 @@ class JokeTest(unittest.TestCase):
         tester = app.test_client(self)
         response = tester.post("/joke/add_user/{}".format(will_deleted_mock_data['name']))
         status = response.status_code
-        self.assertEqual(200, status)
+        self.assertEqual(201, status)
 
     # test for updating a user
     def test_api_update_user(self):

--- a/practice_app/tests/test.py
+++ b/practice_app/tests/test.py
@@ -1,0 +1,132 @@
+try:
+    import sys
+    sys.path.insert(1, '../')
+    from app import app
+    import app as application
+    import unittest
+    import requests
+    import pymongo
+
+except ImportError as e:
+    print("Requirements did not satisfied related to import statements")
+
+
+mock_data = {
+    "name": "mock_user",
+    "jokes": [
+        {
+            "set_up": "set_up_value_one",
+            "punch_line": "punch_line_value_one"
+        },
+        {
+            "set_up": "set_up_value_two",
+            "punch_line": "punch_line_value_two"
+        }
+    ]
+}
+
+will_deleted_mock_data = {
+    "name": "will_deleted_mock_data",
+    "jokes": [
+
+    ]
+}
+
+will_appended_joke = {
+    "name": "will_deleted_mock_data",
+    "set_up": "set_up_value_three",
+    "punch_line": "punch_line_value_three"
+}
+
+
+def equality_check(datum_one, datum_two):
+    if datum_one["name"] != datum_two["name"]:
+        return False
+    for d_one, d_two in zip(datum_one["jokes"], datum_two["jokes"]):
+        if d_one != d_two:
+            return False
+
+    return True
+
+
+class JokeTest(unittest.TestCase):
+
+    # get test of home route
+    def test_get_home(self):
+        tester = app.test_client(self)
+        response = tester.get("/joke/")
+        status = response.status_code
+        self.assertEqual(200, status)
+
+    # get test of choice route
+    def test_get_choice(self):
+        tester = app.test_client(self)
+        response = tester.get("/joke/choice")
+        status = response.status_code
+        self.assertEqual(200, status)
+
+    # get test of make a joke route
+    def test_get_make(self):
+        tester = app.test_client(self)
+        application.joke_user[0] = True
+        application.joke_user[1] = "Onur"
+        response = tester.get("/joke/user/make")
+        status = response.status_code
+        self.assertEqual(200, status)
+
+    # get test of show jokes route
+    def test_get_show(self):
+        tester = app.test_client(self)
+        application.joke_user[0] = True
+        application.joke_user[1] = "Onur"
+        response = tester.get("/joke/user/show")
+        status = response.status_code
+        self.assertEqual(200, status)
+
+    # redirect property oh unrelated url
+    def test_get_unrelated_url(self):
+        tester = app.test_client(self)
+        response = tester.get("/joke/user/unrelated")
+        status = response.status_code
+        self.assertEqual(302, status)
+
+    # test for getting user information
+    def test_api_get_user_info(self):
+        tester = app.test_client(self)
+        response = tester.get("/joke/get_user/{}".format(mock_data["name"]))
+        status = response.status_code
+        self.assertEqual(200, status)
+        self.assertFalse(not equality_check(response.json, mock_data))
+
+    # test for adding a user
+    def test_api_add_user(self):
+        tester = app.test_client(self)
+        response = tester.post("/joke/add_user/{}".format(will_deleted_mock_data['name']))
+        status = response.status_code
+        self.assertEqual(200, status)
+
+    # test for updating a user
+    def test_api_update_user(self):
+        tester = app.test_client(self)
+        set_up = will_appended_joke["set_up"]
+        punch_line = will_appended_joke["punch_line"]
+        response = tester.put('/joke/add_to_list/{}/{}/{}'.format("update_user", set_up, punch_line))
+        status = response.status_code
+        self.assertEqual(200, status)
+
+    # test for deleting a user
+    def test_api_delete_user(self):
+        tester = app.test_client(self)
+        name = will_deleted_mock_data["name"]
+        response = tester.delete("/joke/delete_user/{}".format(name))
+        status = response.status_code
+        self.assertEqual(200, status)
+        self.assertFalse(response.json['deleted_count'] > 1)
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have offered a test mechanism for Joke App inside the practice_app directory which checks the capability of the app to handle the viewing operations and API call operations. It checks the following API's: My first API for getting user information. It shows the user name and the liked jokes of the user. Second API is for adding a user to db. It addes a new document to mongoDB collection and creates an empty list of liked jokes. Third API is for updating the favorite jokes of a user. It adds one by one the favored jokes. Last one is for deleting a user from the db. Actually our application does not allow to enable a user to delete itself but in test mechanism we should remove the addition operation. With this branch I also modified the return types of the API helper functions regarding to the json format.