### PR TITLE
Backend/endpoint/subscribe unsubscribe

### DIFF
--- a/purbee_backend/backend_source/app.py
+++ b/purbee_backend/backend_source/app.py
@@ -55,7 +55,7 @@ def subscribe_to_community_page():
             data['response_message'] = "Registered user with the id {} successfully subscribed to Community with " \
                                        "the id {}".format(req['user_id'], req['community_id'])
             data['community'] = current_community
-            status_code = SC_CREATED
+            status_code = SC_SUCCESS
             return data, status_code
         elif result == 1:
             # update failed
@@ -80,7 +80,7 @@ def subscribe_to_community_page():
         elif result == 10:
             data['response_message'] = "Registered user {} added to the requester list".format(req['user_id'])
             data['community'] = current_community
-            status_code = SC_CREATED
+            status_code = SC_SUCCESS
             return data, status_code
 
 

--- a/purbee_backend/backend_source/app.py
+++ b/purbee_backend/backend_source/app.py
@@ -73,7 +73,7 @@ def subscribe_to_community_page():
             status_code = SC_FORBIDDEN
             return data, status_code
         elif result == 12:
-            data['response_message'] = "There is no registered user wit hte id {}".format(req['user_id'])
+            data['response_message'] = "There is no registered user with the id {}".format(req['user_id'])
             status_code = SC_FORBIDDEN
             # there is no user
             return data, status_code
@@ -83,6 +83,57 @@ def subscribe_to_community_page():
             status_code = SC_CREATED
             return data, status_code
 
+
+@app.route('/api/community_page/unsubscribe', methods=["PUT"])
+def unsubscribe_from_community_page():
+    req = request.get_json()
+    data = {'response_message': None}
+    status_code = None
+    if request.method == "PUT":
+        needed_keys = ['user_id', 'community_id']
+        if len(needed_keys) != len(req):
+            # return invalid input error
+            pass
+        for r_keys in req:
+            if r_keys in needed_keys:
+                pass
+            else:
+                # return invalid input error
+                pass
+
+    result, current_community = Community.unsubscribe(req['user_id'], req['community_id'])
+
+    if result == 0:
+        # successfully removed subscription from private or non private community
+        data['response_message'] = "Registered user with the id {} successfully unsubscribed".format(req['user_id'])
+        data['community'] = current_community
+        status_code = SC_CREATED
+        return data, status_code
+    elif result == 10:
+        # successfully removed request from private community
+        data['response_message'] = "Registered user with the id {} successfully removed subscription request".format(req['user_id'])
+        data['community'] = current_community
+        status_code = SC_CREATED
+        return data, status_code
+    elif result == 1:
+        # update failed
+        data['response_message'] = "Some internal error occured"
+        status_code = SC_INTERNAL_ERROR
+        return data, status_code
+    elif result == 2:
+        # user is not subscriber or requester
+        data['response_message'] = "Registered user with the id {} is not subscriber or subscription requester of the " \
+                                   "community with the id {}".format(req['user_id'], req['community_id'])
+        status_code = SC_FORBIDDEN
+        return data, status_code
+    elif result == 11:
+        # there is no community
+        data['response_message'] = "There is no community with the id {}".format(req['community_id'])
+        status_code = SC_FORBIDDEN
+        return data, status_code
+    elif result == 10:
+        # there is no user
+        data['response_message'] = "There is no registered user with the id {}".format(req['user_id'])
 
 
 @app.route('/api/community_page/', methods=['POST', 'GET', 'PUT'])

--- a/purbee_backend/backend_source/app.py
+++ b/purbee_backend/backend_source/app.py
@@ -27,6 +27,64 @@ USER_PASSWORD = ""
 app = Flask(__name__)
 
 
+@app.route('/api/community_page/subscribe', methods=["PUT"])
+def subscribe_to_community_page():
+    req = request.get_json()
+    data = {"response_message": None}
+    status_code = None
+    if request.method == "PUT":
+        needed_keys = ['user_id', 'community_id']
+        if len(needed_keys) != len(req):
+            # return invalid input error
+            data['response_message'] = "Incorrect son content. (necessary fields are user_id and community_id)"
+            status_code = SC_BAD_REQUEST
+            return data, status_code
+        for r_keys in req:
+            if r_keys in needed_keys:
+                pass
+            else:
+                # return invalid input error
+                data['response_message'] = "Incorrect son content. (necessary fields are user_id and community_id)"
+                status_code = SC_BAD_REQUEST
+                return data, status_code
+
+        result, current_community = Community.subscribe(req['user_id'], req['community_id'])
+
+        if result == 0:
+            # successful
+            data['response_message'] = "Registered user with the id {} successfully subscribed to Community with " \
+                                       "the id {}".format(req['user_id'], req['community_id'])
+            data['community'] = current_community
+            status_code = SC_CREATED
+            return data, status_code
+        elif result == 1:
+            # update failed
+            data['response_message'] = "Some internal error occured"
+            status_code = SC_INTERNAL_ERROR
+            return data, status_code
+        elif result == 2:
+            # user is already subscriber
+            data['response_message'] = "Registered user with the id {} is already subscriber".format(req['user_id'])
+            status_code = SC_FORBIDDEN
+            return data, status_code
+        elif result == 11:
+            # there is no community
+            data['response_message'] = "There is no community with the id {}".format(req['community_id'])
+            status_code = SC_FORBIDDEN
+            return data, status_code
+        elif result == 12:
+            data['response_message'] = "There is no registered user wit hte id {}".format(req['user_id'])
+            status_code = SC_FORBIDDEN
+            # there is no user
+            return data, status_code
+        elif result == 10:
+            data['response_message'] = "Registered user {} added to the requester list".format(req['user_id'])
+            data['community'] = current_community
+            status_code = SC_CREATED
+            return data, status_code
+
+
+
 @app.route('/api/community_page/', methods=['POST', 'GET', 'PUT'])
 def community_page():
     req = request.get_json()

--- a/purbee_backend/backend_source/app.py
+++ b/purbee_backend/backend_source/app.py
@@ -64,7 +64,7 @@ def subscribe_to_community_page():
             return data, status_code
         elif result == 2:
             # user is already subscriber
-            data['response_message'] = "Registered user with the id {} is already subscriber".format(req['user_id'])
+            data['response_message'] = "Registered user with the id {} is already subscriber or requester".format(req['user_id'])
             status_code = SC_FORBIDDEN
             return data, status_code
         elif result == 11:

--- a/purbee_backend/backend_source/community/community.py
+++ b/purbee_backend/backend_source/community/community.py
@@ -84,12 +84,32 @@ class Community:
             self.subscriber_list = neu_subscriber_list
         return result
 
+    def remove_subscriber(self, user_id):
+        neu_subscriber_list = self.subscriber_list
+        neu_subscriber_list.remove(user_id)
+        community_dictionary = self.to_dict()
+        community_dictionary['subscriber_list'] = neu_subscriber_list
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.subscriber_list = neu_subscriber_list
+        return result
+
     def add_requester(self, user_id):
         if user_id in self.subscriber_list or user_id in self.requesters:
             # already subscriber
             return 2
         neu_requester_list = self.requesters
         neu_requester_list.append(user_id)
+        community_dictionary = self.to_dict()
+        community_dictionary['requesters'] = neu_requester_list
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.requesters = neu_requester_list
+        return result
+
+    def remove_requester(self, user_id):
+        neu_requester_list = self.requesters
+        neu_requester_list.remove(user_id)
         community_dictionary = self.to_dict()
         community_dictionary['requesters'] = neu_requester_list
         result = update_community(community_dictionary)
@@ -143,3 +163,43 @@ class Community:
                 return 0, current_community.to_dict()
         return result, None
 
+    @staticmethod
+    def unsubscribe(user_id, community_id):
+        current_community_dict = get_community_by_community_id(community_id)
+        if current_community_dict is None:
+            # there is no community with the given community id
+            return 11, None
+        current_user = get_user_by_name(user_id)
+        if current_user is None:
+            # there is no user with the given user id
+            return 12, None
+        current_community = Community(current_community_dict)
+        if current_community.is_private:
+            if user_id in current_community.requesters:
+                result = current_community.remove_requester(user_id)
+                if result == 0:
+                    # return success
+                    return 10, current_community.to_dict()
+            elif user_id in current_community.subscriber_list:
+                result = current_community.remove_subscriber(user_id)
+                if result == 0:
+                    # retrun success
+                    return 0, current_community.to_dict()
+                else:
+                    # return fail
+                    return 1, None
+            else:
+                # return fail
+                return 2, None
+        else:
+            if user_id in current_community.subscriber_list:
+                result = current_community.remove_subscriber(user_id)
+                if result == 0:
+                    # return success
+                    return 0, current_community.to_dict()
+                else:
+                    # return fail
+                    return 1, None
+            else:
+                # return fail
+                return 2, None

--- a/purbee_backend/backend_source/community/community.py
+++ b/purbee_backend/backend_source/community/community.py
@@ -1,7 +1,8 @@
 from database.database_utilities import (
     save_new_community,
     get_community_by_community_id,
-    update_community
+    update_community,
+    get_user_by_name
 )
 
 
@@ -14,6 +15,7 @@ class Community:
         self.subscriber_list = []
         self.post_type_id_list = []
         self.post_history_id_list = []
+        self.requesters = []
         self.description = ""
         self.photo = None
         self.community_creator_id = None
@@ -40,6 +42,7 @@ class Community:
             'post_history_id_list': self.post_history_id_list,
             'description': self.description,
             'photo': self.photo,
+            'requesters': self.requesters,
             'community_creator_id': self.community_creator_id,
             'created_at': self.created_at,
             'banned_user_list': self.banned_user_list,
@@ -67,6 +70,32 @@ class Community:
             self.subscriber_list = neu_subscriber_list
         return result
 
+    def add_subscriber(self, user_id):
+        neu_subscriber_list = self.subscriber_list
+        if user_id in neu_subscriber_list:
+            # already subscriber
+            return 2
+        neu_subscriber_list.append(user_id)
+        community_dictionary = self.to_dict()
+        community_dictionary['subscriber_list'] = neu_subscriber_list
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.subscriber_list = neu_subscriber_list
+        return result
+
+    def add_requester(self, user_id):
+        if user_id in self.subscriber_list:
+            # already subscriber
+            return 2
+        neu_requester_list = self.requesters
+        neu_requester_list.append(user_id)
+        community_dictionary = self.to_dict()
+        community_dictionary['requesters'] = neu_requester_list
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.requesters = neu_requester_list
+        return result
+
     def ban_member(self, user_id):
         neu_subscriber_list = self.subscriber_list
         neu_banned_user_list = self.banned_user_list
@@ -87,8 +116,27 @@ class Community:
     @staticmethod
     def get_community_from_id(community_id):
         community_dict = get_community_by_community_id(community_id)
-        print("community_dict", community_dict)
         if community_dict:
             return Community(community_dict)
         return None
+
+    @staticmethod
+    def subscribe(user_id, community_id):
+        current_community = get_community_by_community_id(community_id)
+        if current_community is None:
+            # there is no community with the given community id
+            return 11, None
+        current_user = get_user_by_name(user_id) # user names and ids are the same
+        if current_user is None:
+            # there is no user with the given user id
+            return 12, None
+        if current_community.is_private:
+            # eger community privatesa
+            result = current_community.add_requester(user_id)
+            if result == 0:
+                return 10, current_community.to_dict()
+        result = current_community.add_subscriber(user_id)
+        if result == 0:
+            return 0, current_community.to_dict()
+        return result, None
 

--- a/purbee_backend/backend_source/community/community.py
+++ b/purbee_backend/backend_source/community/community.py
@@ -4,6 +4,7 @@ from database.database_utilities import (
     update_community,
     get_user_by_name
 )
+import sys
 
 
 class Community:
@@ -71,10 +72,10 @@ class Community:
         return result
 
     def add_subscriber(self, user_id):
-        neu_subscriber_list = self.subscriber_list
-        if user_id in neu_subscriber_list:
+        if user_id in self.subscriber_list:
             # already subscriber
             return 2
+        neu_subscriber_list = self.subscriber_list
         neu_subscriber_list.append(user_id)
         community_dictionary = self.to_dict()
         community_dictionary['subscriber_list'] = neu_subscriber_list
@@ -84,7 +85,7 @@ class Community:
         return result
 
     def add_requester(self, user_id):
-        if user_id in self.subscriber_list:
+        if user_id in self.subscriber_list or user_id in self.requesters:
             # already subscriber
             return 2
         neu_requester_list = self.requesters
@@ -122,21 +123,23 @@ class Community:
 
     @staticmethod
     def subscribe(user_id, community_id):
-        current_community = get_community_by_community_id(community_id)
-        if current_community is None:
+        current_community_dict = get_community_by_community_id(community_id)
+        if current_community_dict is None:
             # there is no community with the given community id
             return 11, None
         current_user = get_user_by_name(user_id) # user names and ids are the same
         if current_user is None:
             # there is no user with the given user id
             return 12, None
+        current_community = Community(current_community_dict)
         if current_community.is_private:
             # eger community privatesa
             result = current_community.add_requester(user_id)
             if result == 0:
                 return 10, current_community.to_dict()
-        result = current_community.add_subscriber(user_id)
-        if result == 0:
-            return 0, current_community.to_dict()
+        else:
+            result = current_community.add_subscriber(user_id)
+            if result == 0:
+                return 0, current_community.to_dict()
         return result, None
 


### PR DESCRIPTION
This branch related operations are mentioned in this issue #220. I have implemented subscription and unsubscription operations related to community page. To implement these functionality i needed to add one more field to communities which is the requesters. Requesters field hold the ids of the registered users. If a registered user wants to subscribe a private community their id stored in this field and after tat, an admin should be able to evaluate this request. 
I have tested the endpoints and everytime got wanted response. But I want you to test again, and report me if any misregulated case. Also, I want you to inspect the implementation of the code.