### PR TITLE
Backend/endpoint/community page/change privacy

### DIFF
--- a/purbee_backend/backend_source/app.py
+++ b/purbee_backend/backend_source/app.py
@@ -36,13 +36,16 @@ def change_privacy_community_page():
         needed_keys = ['community_id', 'admin_id']
         if len(needed_keys) != len(req):
             # return invalid input error
-            pass
+            data['response_message'] = "Incorrect json content. (necessary fields are admin_id and community_id)"
+            status_code = SC_BAD_REQUEST
+            return data, status_code
         for r_keys in req:
             if r_keys in needed_keys:
                 pass
             else:
                 # return invalid input error
-                pass
+                data['response_message'] = "Incorrect json content. (necessary fields are admin_id and community_id)"
+                status_code = SC_BAD_REQUEST
 
         result, current_community = Community.change_privacy(req['admin_id'], req['community_id'])
 
@@ -50,12 +53,12 @@ def change_privacy_community_page():
             # successful make private
             data['response_message'] = "Community privacy set to private"
             data['community'] = current_community
-            status_code = SC_CREATED
+            status_code = SC_SUCCESS
         elif result == 10:
             # successful make public
             data['response_message'] = "Community privacy set to public"
             data['community'] = current_community
-            status_code = SC_CREATED
+            status_code = SC_SUCCESS
         elif result == 11:
             data['response_message'] = "There is no community with the given community id {}".format(req['community_id'])
             status_code = SC_FORBIDDEN

--- a/purbee_backend/backend_source/app.py
+++ b/purbee_backend/backend_source/app.py
@@ -27,6 +27,50 @@ USER_PASSWORD = ""
 app = Flask(__name__)
 
 
+@app.route('/api/community_page/change_privacy', methods=["PUT"])
+def change_privacy_community_page():
+    req = request.get_json()
+    data = {"response_message": None}
+    status_code = None
+    if request.method == "PUT":
+        needed_keys = ['community_id', 'admin_id']
+        if len(needed_keys) != len(req):
+            # return invalid input error
+            pass
+        for r_keys in req:
+            if r_keys in needed_keys:
+                pass
+            else:
+                # return invalid input error
+                pass
+
+        result, current_community = Community.change_privacy(req['admin_id'], req['community_id'])
+
+        if result == 0:
+            # successful make private
+            data['response_message'] = "Community privacy set to private"
+            data['community'] = current_community
+            status_code = SC_CREATED
+        elif result == 10:
+            # successful make public
+            data['response_message'] = "Community privacy set to public"
+            data['community'] = current_community
+            status_code = SC_CREATED
+        elif result == 11:
+            data['response_message'] = "There is no community with the given community id {}".format(req['community_id'])
+            status_code = SC_FORBIDDEN
+        elif result == 12:
+            data['response_message'] = "There is no user with the given registered user id {}".format(req['admin_id'])
+            status_code = SC_FORBIDDEN
+        elif result == 13:
+            data['response_message'] = "The user with the given id {} is not an admin of the community {}".format(req['admin_id'], req['community_id'])
+            status_code = SC_FORBIDDEN
+        elif result == 1:
+            data['response_message'] = "Some internal error occurred"
+            status_code = SC_INTERNAL_ERROR
+        return data, status_code
+
+
 @app.route('/api/community_page/', methods=['POST', 'GET', 'PUT'])
 def community_page():
     req = request.get_json()

--- a/purbee_backend/backend_source/community/community.py
+++ b/purbee_backend/backend_source/community/community.py
@@ -1,7 +1,8 @@
 from database.database_utilities import (
     save_new_community,
     get_community_by_community_id,
-    update_community
+    update_community,
+    get_user_by_name
 )
 
 
@@ -12,6 +13,7 @@ class Community:
         # self.next_post_type_id = None
         self.admin_list = []
         self.subscriber_list = []
+        self.requesters = []
         self.post_type_id_list = []
         self.post_history_id_list = []
         self.description = ""
@@ -43,7 +45,8 @@ class Community:
             'community_creator_id': self.community_creator_id,
             'created_at': self.created_at,
             'banned_user_list': self.banned_user_list,
-            'is_private': self.is_private
+            'is_private': self.is_private,
+            'requesters': self.requesters
         }
         return dict_object
 
@@ -84,6 +87,27 @@ class Community:
     def get_post_types(self):
         return self.post_type_id_list
 
+    def make_private(self):
+        community_dictionary = self.to_dict()
+        community_dictionary['is_private'] = True
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.is_private = True
+        return result
+
+    def make_public(self):
+        community_dictionary = self.to_dict()
+        community_dictionary['is_private'] = False
+        before_requesters = community_dictionary['requesters']
+        community_dictionary['requesters'] = []
+        subscribers = community_dictionary['subscriber_list']
+        subscribers.extend(before_requesters)
+        community_dictionary['subscriber_list'] = subscribers
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.update(community_dictionary)
+        return result
+
     @staticmethod
     def get_community_from_id(community_id):
         community_dict = get_community_by_community_id(community_id)
@@ -92,3 +116,33 @@ class Community:
             return Community(community_dict)
         return None
 
+    @staticmethod
+    def change_privacy(admin_id, community_id):
+        community_dict = get_community_by_community_id(community_id)
+        if community_dict is None:
+            # there is no community with the given community id
+            return 11, None
+        current_user = get_user_by_name(admin_id)
+        if current_user is None:
+            # there is no user with the given admin id
+            return 12, None
+        if not admin_id in community_dict['admin_list']:
+            # given registered user is not the admin of the given community
+            return 13, None
+        current_community = Community(community_dict)
+        if current_community.is_private:
+            result = current_community.make_public()
+            if result == 0:
+                # return success to change to public
+                return 10, current_community.to_dict()
+            else:
+                # return fail
+                return 1, None
+        else:
+            result = current_community.make_private()
+            if result == 0:
+                # return success to change to private
+                return 0, current_community.to_dict()
+            else:
+                # return fail
+                return 1, None


### PR DESCRIPTION
I have implemented the feature in which an admin will be able to change the privacy option of the community page. If the community page was not private, the privacy set to true. On the other hand, if the privacy option was private, the subscription requesters automatically evaluated as subscribers. After subscriber related operations handled, the privacy option set to non private. Related issue is #224. 