### PR TITLE
Backend/endpoint/community page/handle admin

### DIFF
--- a/purbee_backend/backend_source/app.py
+++ b/purbee_backend/backend_source/app.py
@@ -28,6 +28,61 @@ USER_PASSWORD = ""
 app = Flask(__name__)
 
 
+@app.route('/api/community_page/admin', methods=['PUT'])
+def community_page_admin():
+    req = request.get_json()
+    data = {'response_message': None}
+    status_code = None
+
+    if request.method == "PUT":
+        needed_keys = ['admin_id', 'user_id', 'community_id', 'action']
+        if len(needed_keys) != len(req):
+            data['response_message'] = "Incorrect json content. (needed keys are admin_id, user_id, community_id, action)"
+            status_code = SC_BAD_REQUEST
+            return data, status_code
+        for r_keys in req:
+            if r_keys in needed_keys:
+                pass
+            else:
+                data['response_message'] = "Incorrect json content. (needed keys are admin_id, user_id, community_id, action)"
+                status_code = SC_BAD_REQUEST
+                return data, status_code
+
+        result, current_community = Community.make_or_remove_admin(req['admin_id'], req['community_id'], req['user_id'], req['action'])
+
+        if result == 0:
+            # successful
+            data['response_message'] = "Registered user successfully changed"
+            data['community'] = current_community
+            status_code = SC_SUCCESS
+        elif result == 1:
+            # internal error
+            data['response_message'] = "Some internal error occurred"
+            status_code = SC_INTERNAL_ERROR
+        elif result == 2:
+            # bad request
+            data['response_message'] = "Incorrect json content. (needed keys are admin_id, user_id, community_id, action)"
+            status_code = SC_BAD_REQUEST
+        elif result == 11:
+            data['response_message'] = "There is no community with the given community id"
+            status_code = SC_FORBIDDEN
+        elif result == 12:
+            data['response_message'] = "There is no registered user with the given user id"
+            status_code = SC_FORBIDDEN
+        elif result == 13:
+            data['response_message'] = "There is no registered user with the given admin id"
+            status_code = SC_FORBIDDEN
+        elif result == 14:
+            data['response_message'] = "Registered user with the admin id is not an admin or community creator"
+            status_code = SC_FORBIDDEN
+        elif result == 15:
+            data['response_message'] = "Registered user with the user id is already an admin"
+            status_code = SC_FORBIDDEN
+        elif result == 16:
+            data['response_message'] = "Registered user with the user id is not an admin"
+            status_code = SC_FORBIDDEN
+
+        return data, status_code
 
 @app.route('/api/community_feed/', methods=['GET'])
 def community_feed():

--- a/purbee_backend/backend_source/community/community.py
+++ b/purbee_backend/backend_source/community/community.py
@@ -203,3 +203,63 @@ class Community:
             else:
                 # return fail
                 return 2, None
+
+    @staticmethod
+    def make_or_remove_admin(admin_id, community_id, user_id, action):
+        if action not in ['make', 'remove']:
+            # bad request
+            return 2, None
+        current_community_dict = get_community_by_community_id(community_id)
+        if current_community_dict is None:
+            # there is no community
+            return 11, None
+        current_user = get_user_by_name(user_id)
+        if current_user is None:
+            # there is no user
+            return 12, None
+        current_admin = get_user_by_name(admin_id)
+        if current_admin is None:
+            # there is no user with the admin_id
+            return 13, None
+        if admin_id not in current_community_dict['admin_list'] or admin_id != current_community_dict['community_creator_id']:
+            # user with the admin_id is not an admin or not and community creator
+            return 14, None
+
+        current_community = Community(current_community_dict)
+        if action == 'make':
+            result = current_community.handle_make_admin(user_id)
+        elif action == 'remove':
+            result = current_community.handle_remove_admin(user_id)
+        else:
+            # bad request
+            return 2, None
+
+        if result == 0:
+            # success
+            return 0, current_community.to_dict()
+        else:
+            return result, None
+
+    def handle_make_admin(self, user_id):
+        community_dictionary = self.to_dict()
+        if user_id in community_dictionary['admin_list']:
+            # user is already an admin
+            return 15
+        neu_admin_list = community_dictionary['admin_list']
+        neu_admin_list.append(user_id)
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.update(community_dictionary)
+        return result
+
+    def handle_remove_admin(self, user_id):
+        community_dictionary = self.to_dict()
+        if user_id not in community_dictionary['admin_list']:
+            # user is not an admin
+            return 16
+        neu_admin_list = community_dictionary['admin_list']
+        neu_admin_list.remove(user_id)
+        result = update_community(community_dictionary)
+        if result == 0:
+            self.update(community_dictionary)
+        return result


### PR DESCRIPTION
The features related this branch is mentioned in the issue #229. It is basically realted to the admin operations in the community pages. When an admin or community creator wants to remove an admin or add an admin, they now will be able to use the created endpoints via frontend. Please inspect the functionalities and make reviews.